### PR TITLE
Ignore broken assemblies when discovering engines

### DIFF
--- a/NEsper/NEsper/script/ScriptingServiceImpl.cs
+++ b/NEsper/NEsper/script/ScriptingServiceImpl.cs
@@ -52,7 +52,17 @@ namespace com.espertech.esper.script
         /// <param name="isEngine">The is engine.</param>
         public void DiscoverEngines(Assembly assembly, Predicate<Type> isEngine)
         {
-            foreach (var type in assembly.GetTypes())
+            Type[] types;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch
+            {
+                // ignore assemblies that cannot be loaded
+                return;
+            }
+            foreach (var type in types)
             {
                 if (type.IsInterface || type.IsAbstract)
                     continue;


### PR DESCRIPTION
In some cases, `assembly.GetTypes()` can fail causing the whole thing to become unusable since it is invoked on initialization. I think it is safe to ignore such assemblies.

In case anybody is interested in what cases  `assembly.GetTypes()`  can fail, one particular example is this one: https://github.com/dotnet/roslyn/issues/9417