### PR TITLE
Fixes instance creation when thread local tied to thread pool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,6 @@ jobs:
       - run: dotnet restore NEsperAll.sln
       - run: msbuild NEsper.proj
       - store_artifacts:
-          path: build/NEsper-8.5.5.zip
+          path: build/NEsper-8.5.6.zip
       - store_artifacts:
           path: build/packages

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<VersionPrefix Condition="'$(VersionPrefix)' == ''">8.5.5</VersionPrefix>
+		<VersionPrefix Condition="'$(VersionPrefix)' == ''">8.5.6</VersionPrefix>
 		<VersionSuffix Condition="'$(VersionSuffix)' == ''"></VersionSuffix>
 	</PropertyGroup>
 

--- a/NEsper.Documentation/NEsper.Documentation.shfbproj
+++ b/NEsper.Documentation/NEsper.Documentation.shfbproj
@@ -16,7 +16,7 @@
     <Name>NEsper.Documentation</Name>
     <!-- SHFB properties -->
     <FrameworkVersion>.NET Framework 4.6.2</FrameworkVersion>
-    <OutputPath>..\build\NEsper-8.5.5\docs\</OutputPath>
+    <OutputPath>..\build\NEsper-8.5.6\docs\</OutputPath>
     <HtmlHelpName>NEsper</HtmlHelpName>
     <Language>en-US</Language>
     <TransformComponentArguments>

--- a/NEsper.nuspec
+++ b/NEsper.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>NEsper</id>
-    <version>8.5.5</version>
+    <version>8.5.6</version>
     <authors>EsperTech</authors>
     <owners>EsperTech</owners>
     <language>en-us</language>
@@ -27,7 +27,7 @@
   </metadata>
 
   <files>
-    <file src="build\NEsper-8.5.5\lib\**" target="lib\{framework name}[{version}]" />
+    <file src="build\NEsper-8.5.6\lib\**" target="lib\{framework name}[{version}]" />
   </files>
 </package>
   

--- a/NEsper.proj
+++ b/NEsper.proj
@@ -8,7 +8,7 @@
     <SolutionDir>$(MSBuildProjectDirectory)</SolutionDir>
     <!-- Distribution version -->
     <Version Condition=" '$(CCNetLabel)' != '' ">$(CCNetLabel)</Version>
-    <Version Condition=" '$(Version)' == '' ">8.5.5</Version>
+    <Version Condition=" '$(Version)' == '' ">8.5.6</Version>
 
     <!-- Build Directories -->
     <BuildPath>$(MSBuildProjectDirectory)\build</BuildPath>

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ env:
   variables:
     MASTER_PROJECT: .\NEsper.proj
     PACKAGE_DIRECTORY: .\packages
-    VERSION: 8.5.5
+    VERSION: 8.5.6
 
 phases:
   build:

--- a/src/NEsper.Common/common/internal/epl/historical/common/HistoricalEventViewableFactoryBase.cs
+++ b/src/NEsper.Common/common/internal/epl/historical/common/HistoricalEventViewableFactoryBase.cs
@@ -37,7 +37,7 @@ namespace com.espertech.esper.common.@internal.epl.historical.common
         }
 
         public IThreadLocal<HistoricalDataCache> DataCacheThreadLocal { get; } =
-            new SlimThreadLocal<HistoricalDataCache>(() => null);
+            new SystemThreadLocal<HistoricalDataCache>(() => null);
 
         public abstract void Ready(
             StatementContext statementContext,

--- a/src/NEsper.Common/common/internal/epl/variable/core/VariableVersionThreadLocal.cs
+++ b/src/NEsper.Common/common/internal/epl/variable/core/VariableVersionThreadLocal.cs
@@ -36,7 +36,7 @@ namespace com.espertech.esper.common.@internal.epl.variable.core
         /// Initializes a new instance of the <see cref="VariableVersionThreadLocal"/> class.
         /// </summary>
         public VariableVersionThreadLocal()
-            : this(new DefaultThreadLocalManager(new SlimThreadLocalFactory()))
+            : this(new DefaultThreadLocalManager(new SystemThreadLocalFactory()))
         {
         }
 

--- a/src/NEsper.Common/common/internal/filterspec/ExprNodeAdapterMSPlain.cs
+++ b/src/NEsper.Common/common/internal/filterspec/ExprNodeAdapterMSPlain.cs
@@ -34,7 +34,7 @@ namespace com.espertech.esper.common.@internal.filterspec
         {
             _variableService = variableService;
 
-            _arrayPerThread = new SlimThreadLocal<EventBean[]>(
+            _arrayPerThread = new SystemThreadLocal<EventBean[]>(
                 () => {
                     var eventsPerStream = new EventBean[prototypeArray.Length];
                     Array.Copy(prototypeArray, 0, eventsPerStream, 0, prototypeArray.Length);

--- a/src/NEsper.Common/common/internal/view/intersect/IntersectViewFactory.cs
+++ b/src/NEsper.Common/common/internal/view/intersect/IntersectViewFactory.cs
@@ -61,21 +61,19 @@ namespace com.espertech.esper.common.@internal.view.intersect
             }
 
             if (_batchViewIndex != -1) {
-                _batchViewLocalState = new SlimThreadLocal<IntersectBatchViewLocalState>(
+                _batchViewLocalState = new SystemThreadLocal<IntersectBatchViewLocalState>(
                     () =>
                         new IntersectBatchViewLocalState(
                             new EventBean[_intersecteds.Length][],
                             new EventBean[_intersecteds.Length][]));
             }
             else if (_hasAsymetric) {
-                _asymetricViewLocalState = new SlimThreadLocal<IntersectAsymetricViewLocalState>(
-                    () =>
-                        new IntersectAsymetricViewLocalState(new EventBean[_intersecteds.Length][]));
+                _asymetricViewLocalState = new SystemThreadLocal<IntersectAsymetricViewLocalState>(
+                    () => new IntersectAsymetricViewLocalState(new EventBean[_intersecteds.Length][]));
             }
             else {
-                _defaultViewLocalState = new SlimThreadLocal<IntersectDefaultViewLocalState>(
-                    () =>
-                        new IntersectDefaultViewLocalState(new EventBean[_intersecteds.Length][]));
+                _defaultViewLocalState = new SystemThreadLocal<IntersectDefaultViewLocalState>(
+                    () => new IntersectDefaultViewLocalState(new EventBean[_intersecteds.Length][]));
             }
         }
 

--- a/src/NEsper.Compiler/internal/util/CompilerVersion.cs
+++ b/src/NEsper.Compiler/internal/util/CompilerVersion.cs
@@ -10,6 +10,6 @@ namespace com.espertech.esper.compiler.@internal.util
 {
     public class CompilerVersion
     {
-        public const string COMPILER_VERSION = "8.5.5";
+        public const string COMPILER_VERSION = "8.5.6";
     }
 } // end of namespace

--- a/src/NEsper.Compiler/internal/util/Version.cs
+++ b/src/NEsper.Compiler/internal/util/Version.cs
@@ -11,7 +11,7 @@ namespace com.espertech.esper.compiler.@internal.util
     public class Version
     {
         public static string COMPILER_VERSION {
-            get => "8.5.5";
+            get => "8.5.6";
         }
     }
 } // end of namespace

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarBaseListener.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarBaseListener.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.5\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.6\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarBaseVisitor.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarBaseVisitor.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.5\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.6\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarLexer.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarLexer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.5\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.6\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarListener.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarListener.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.5\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.6\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarParser.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarParser.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.5\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.6\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarVisitor.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarVisitor.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.5\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.6\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Runtime/client/util/RuntimeVersion.cs
+++ b/src/NEsper.Runtime/client/util/RuntimeVersion.cs
@@ -19,7 +19,7 @@ namespace com.espertech.esper.runtime.client.util
         /// <summary>
         ///     Current runtime version.
         /// </summary>
-        public const string RUNTIME_VERSION = "8.5.5";
+        public const string RUNTIME_VERSION = "8.5.6";
 
         /// <summary>
         ///     Current runtime major version.

--- a/src/NEsper.Runtime/internal/kernel/service/StatementResultServiceImpl.cs
+++ b/src/NEsper.Runtime/internal/kernel/service/StatementResultServiceImpl.cs
@@ -69,7 +69,7 @@ namespace com.espertech.esper.runtime.@internal.kernel.service
             StatementInformationalsRuntime statementInformationals,
             EPServicesContext epServicesContext)
         {
-            StatementDispatchTl = new SlimThreadLocal<StatementDispatchTLEntry>(() => new StatementDispatchTLEntry());
+            StatementDispatchTl = new SystemThreadLocal<StatementDispatchTLEntry>(() => new StatementDispatchTLEntry());
             _statementInformationals = statementInformationals;
             _epServicesContext = epServicesContext;
             _outboundThreading = epServicesContext.ThreadingService.IsOutboundThreading;
@@ -253,7 +253,10 @@ namespace com.espertech.esper.runtime.@internal.kernel.service
 
         public void ClearDeliveriesRemoveStream(EventBean[] removedEvents)
         {
-            var entry = DispatchTL.GetOrCreate();
+            var entry = DispatchTL.Value;
+            if (entry == null) {
+                return;
+            }
 
             entry.Results.RemoveWhere(
                 pair => {

--- a/src/NEsper.Runtime/internal/metrics/codahale_metrics/metrics/stats/ThreadLocalRandom.cs
+++ b/src/NEsper.Runtime/internal/metrics/codahale_metrics/metrics/stats/ThreadLocalRandom.cs
@@ -26,7 +26,7 @@ namespace com.espertech.esper.runtime.@internal.metrics.codahale_metrics.metrics
         ///     The actual ThreadLocal
         /// </summary>
         private static readonly IThreadLocal<ThreadLocalRandom> LOCAL_RANDOM_THREAD_LOCAL =
-            new SlimThreadLocal<ThreadLocalRandom>(() => new ThreadLocalRandom());
+            new SystemThreadLocal<ThreadLocalRandom>(() => new ThreadLocalRandom());
 
         /// <summary>
         ///     Initialization flag to permit calls to setSeed to succeed only while executing the Random

--- a/tst/NEsper.Regression/suite/client/deploy/ClientDeployVersion.cs
+++ b/tst/NEsper.Regression/suite/client/deploy/ClientDeployVersion.cs
@@ -37,7 +37,7 @@ namespace com.espertech.esper.regressionlib.suite.client.deploy
 				EPCompiled compiled = EPCompiledIOUtil.Read(new File(file));
 
 				var versionMismatchMsg =
-					"Major or minor version of compiler and runtime mismatch; The runtime version is 8.5.5 and the compiler version of the compiled unit is 8.0.0";
+					"Major or minor version of compiler and runtime mismatch; The runtime version is 8.5.6 and the compiler version of the compiled unit is 8.0.0";
 				AssertMessage(
 					Assert.Throws<EPDeployDeploymentVersionException>(
 						() => env.Runtime.DeploymentService.Deploy(compiled)),
@@ -51,7 +51,7 @@ namespace com.espertech.esper.regressionlib.suite.client.deploy
 				AssertMessage(
 					Assert.Throws<EPException>(
 						() => env.Runtime.FireAndForgetService.ExecuteQuery(compiled)),
-					"Major or minor version of compiler and runtime mismatch; The runtime version is 8.5.5 and the compiler version of the compiled unit is 8.0.0");
+					"Major or minor version of compiler and runtime mismatch; The runtime version is 8.5.6 and the compiler version of the compiled unit is 8.0.0");
 #endif
 			}
 		}


### PR DESCRIPTION
Identified a problem where timers can dispatch to thread pool based threads.  These threads then cause the thread local to create new object instances.  This PR fixes two problems:

- Changes the default thread local to SystemThreadLocal.  The .NET framework is now sufficiently mature that the default implementation is sufficient for most uses.
- Changing behavior in NamedWindowDispatchServiceImpl to use thread local (and test) rather than creation.
  - This should have been the default behavior.  It avoids situations of dispatching on threads when there are no events.