### PR TITLE
Addressing compile & runtime issues for plugin-style assemblies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,6 @@ jobs:
       - run: dotnet restore NEsperAll.sln
       - run: msbuild NEsper.proj
       - store_artifacts:
-          path: build/NEsper-8.5.6.zip
+          path: build/NEsper-8.5.7.zip
       - store_artifacts:
           path: build/packages

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<VersionPrefix Condition="'$(VersionPrefix)' == ''">8.5.6</VersionPrefix>
+		<VersionPrefix Condition="'$(VersionPrefix)' == ''">8.5.7</VersionPrefix>
 		<VersionSuffix Condition="'$(VersionSuffix)' == ''"></VersionSuffix>
 	</PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,6 +46,11 @@
 		<DefineConstants>$(DefineConstants);NETCORE;</DefineConstants>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)'=='net7.0'">
+		<NetCore>true</NetCore>
+		<DefineConstants>$(DefineConstants);NETCORE;NET5;NET6;NET7;</DefineConstants>
+	</PropertyGroup>
+
 	<PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
 		<NetCore>true</NetCore>
 		<DefineConstants>$(DefineConstants);NETCORE;NET5;NET6;</DefineConstants>

--- a/NEsper.Documentation/NEsper.Documentation.shfbproj
+++ b/NEsper.Documentation/NEsper.Documentation.shfbproj
@@ -16,7 +16,7 @@
     <Name>NEsper.Documentation</Name>
     <!-- SHFB properties -->
     <FrameworkVersion>.NET Framework 4.6.2</FrameworkVersion>
-    <OutputPath>..\build\NEsper-8.5.6\docs\</OutputPath>
+    <OutputPath>..\build\NEsper-8.5.7\docs\</OutputPath>
     <HtmlHelpName>NEsper</HtmlHelpName>
     <Language>en-US</Language>
     <TransformComponentArguments>

--- a/NEsper.nuspec
+++ b/NEsper.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>NEsper</id>
-    <version>8.5.6</version>
+    <version>8.5.7</version>
     <authors>EsperTech</authors>
     <owners>EsperTech</owners>
     <language>en-us</language>
@@ -27,7 +27,7 @@
   </metadata>
 
   <files>
-    <file src="build\NEsper-8.5.6\lib\**" target="lib\{framework name}[{version}]" />
+    <file src="build\NEsper-8.5.7\lib\**" target="lib\{framework name}[{version}]" />
   </files>
 </package>
   

--- a/NEsper.proj
+++ b/NEsper.proj
@@ -8,7 +8,7 @@
     <SolutionDir>$(MSBuildProjectDirectory)</SolutionDir>
     <!-- Distribution version -->
     <Version Condition=" '$(CCNetLabel)' != '' ">$(CCNetLabel)</Version>
-    <Version Condition=" '$(Version)' == '' ">8.5.6</Version>
+    <Version Condition=" '$(Version)' == '' ">8.5.7</Version>
 
     <!-- Build Directories -->
     <BuildPath>$(MSBuildProjectDirectory)\build</BuildPath>

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ env:
   variables:
     MASTER_PROJECT: .\NEsper.proj
     PACKAGE_DIRECTORY: .\packages
-    VERSION: 8.5.6
+    VERSION: 8.5.7
 
 phases:
   build:

--- a/src/NEsper.Common/common/client/artifact/ArtifactRepositoryAssemblyLoadContext.cs
+++ b/src/NEsper.Common/common/client/artifact/ArtifactRepositoryAssemblyLoadContext.cs
@@ -10,14 +10,14 @@ using com.espertech.esper.compat.collections;
 using com.espertech.esper.compat.function;
 using com.espertech.esper.compat.logging;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 using System.Reflection;
 using System.Runtime.Loader;
 #endif
 
 namespace com.espertech.esper.common.client.artifact
 {
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
     public class ArtifactRepositoryAssemblyLoadContext : BaseArtifactRepository, IDisposable
     {
         private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);

--- a/src/NEsper.Common/common/client/artifact/ArtifactRepositoryAssemblyLoadContext.cs
+++ b/src/NEsper.Common/common/client/artifact/ArtifactRepositoryAssemblyLoadContext.cs
@@ -23,7 +23,7 @@ namespace com.espertech.esper.common.client.artifact
         private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
         private AssemblyLoadContext _assemblyLoadContext;
-        private TypeResolver _typeResolver;
+        private readonly TypeResolver _typeResolver;
 
         /// <summary>
         /// Returns the assembly load context
@@ -34,10 +34,14 @@ namespace com.espertech.esper.common.client.artifact
         /// Constructor.
         /// </summary>
         /// <param name="parentTypeResolver"></param>
-        public ArtifactRepositoryAssemblyLoadContext(TypeResolver parentTypeResolver)
+        /// <param name="assemblyResolver"></param>
+        public ArtifactRepositoryAssemblyLoadContext(
+            TypeResolver parentTypeResolver,
+            AssemblyResolver assemblyResolver)
         {
             _assemblyLoadContext = CreateAssemblyLoadContext(
                 this,
+                assemblyResolver,
                 "default-artifact-repository-assembly-load-context",
                 true);
             _typeResolver = new ArtifactTypeResolver(this, parentTypeResolver);
@@ -48,12 +52,15 @@ namespace com.espertech.esper.common.client.artifact
         /// </summary>
         /// <param name="deploymentId"></param>
         /// <param name="parentTypeResolver"></param>
+        /// <param name="assemblyResolver"></param>
         public ArtifactRepositoryAssemblyLoadContext(
             string deploymentId,
-            TypeResolver parentTypeResolver)
+            TypeResolver parentTypeResolver,
+            AssemblyResolver assemblyResolver)
         {
             _assemblyLoadContext = CreateAssemblyLoadContext(
                 this,
+                assemblyResolver,
                 "artifact-repository-assembly-load-context-" + deploymentId,
                 true);
             _typeResolver = new ArtifactTypeResolver(this, parentTypeResolver);
@@ -93,6 +100,7 @@ namespace com.espertech.esper.common.client.artifact
 
         public static AssemblyLoadContext CreateAssemblyLoadContext(
             IArtifactRepository repository,
+            AssemblyResolver assemblyResolver,
             string contextName,
             bool isCollectable)
         {
@@ -105,6 +113,10 @@ namespace com.espertech.esper.common.client.artifact
                         var assemblyBaseName = assemblyName.Name;
                         var artifact = repositoryInstance.Resolve(assemblyBaseName);
                         var assembly = artifact?.Assembly;
+                        if (assembly == null) {
+                            assembly = assemblyResolver?.Invoke(assemblyName);
+                        }
+                        
                         return assembly;
                     }
 

--- a/src/NEsper.Common/common/client/artifact/ArtifactRepositoryExtensions.cs
+++ b/src/NEsper.Common/common/client/artifact/ArtifactRepositoryExtensions.cs
@@ -4,7 +4,7 @@ using com.espertech.esper.common.@internal.util;
 using com.espertech.esper.compat;
 using com.espertech.esper.compat.collections;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
 
@@ -37,8 +37,5 @@ namespace com.espertech.esper.common.client.artifact
                     : null;
             return new DefaultArtifactRepositoryManager(baseTypeResolver, assemblyResolver);
         }
-
-#if NETCORE
-#endif
     }
 }

--- a/src/NEsper.Common/common/client/artifact/ArtifactRepositoryExtensions.cs
+++ b/src/NEsper.Common/common/client/artifact/ArtifactRepositoryExtensions.cs
@@ -32,7 +32,10 @@ namespace com.espertech.esper.common.client.artifact
             var baseTypeResolver = container.Has<TypeResolver>()
                 ? container.Resolve<TypeResolver>()
                 : TypeResolverDefault.INSTANCE;
-            return new DefaultArtifactRepositoryManager(baseTypeResolver);
+            var assemblyResolver = container.Has<AssemblyResolver>()
+                    ? container.Resolve<AssemblyResolver>()
+                    : null;
+            return new DefaultArtifactRepositoryManager(baseTypeResolver, assemblyResolver);
         }
 
 #if NETCORE

--- a/src/NEsper.Common/common/client/artifact/BaseArtifactRepository.cs
+++ b/src/NEsper.Common/common/client/artifact/BaseArtifactRepository.cs
@@ -10,7 +10,7 @@ using com.espertech.esper.compat.function;
 
 using Microsoft.CodeAnalysis;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
 

--- a/src/NEsper.Common/common/client/artifact/DefaultArtifactRepositoryManager.cs
+++ b/src/NEsper.Common/common/client/artifact/DefaultArtifactRepositoryManager.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 using com.espertech.esper.compat;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
 
@@ -21,7 +21,7 @@ namespace com.espertech.esper.common.client.artifact
         private readonly TypeResolver _parentTypeResolver;
         private readonly AssemblyResolver _assemblyResolver;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
         public DefaultArtifactRepositoryManager(
             TypeResolver parentTypeResolver,
             AssemblyResolver assemblyResolver)
@@ -33,7 +33,7 @@ namespace com.espertech.esper.common.client.artifact
             _assemblyResolver = assemblyResolver;
             _repositoryTable = new Dictionary<string, IArtifactRepository>();
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
             DefaultRepository = new ArtifactRepositoryAssemblyLoadContext(
                 _parentTypeResolver, _assemblyResolver);
 #else
@@ -73,7 +73,7 @@ namespace com.espertech.esper.common.client.artifact
         {
             lock (_repositoryTable) {
                 if (!_repositoryTable.TryGetValue(deploymentId, out var artifactRepository) && createIfMissing) {
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
                     artifactRepository = new ArtifactRepositoryAssemblyLoadContext(
                         deploymentId,
                         _parentTypeResolver,

--- a/src/NEsper.Common/common/client/artifact/MetadataReferenceProvider.cs
+++ b/src/NEsper.Common/common/client/artifact/MetadataReferenceProvider.cs
@@ -5,7 +5,7 @@ using com.espertech.esper.common.@internal.util;
 using com.espertech.esper.compat;
 using com.espertech.esper.compat.collections;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
 

--- a/src/NEsper.Common/common/client/artifact/MetadataReferenceProvider.cs
+++ b/src/NEsper.Common/common/client/artifact/MetadataReferenceProvider.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+
+using com.espertech.esper.common.@internal.util;
+using com.espertech.esper.compat;
+using com.espertech.esper.compat.collections;
+
+#if NETCORE
+using System.Runtime.Loader;
+#endif
+
+using com.espertech.esper.container;
+
+using Microsoft.CodeAnalysis;
+
+namespace com.espertech.esper.common.client.artifact
+{
+    public delegate IEnumerable<MetadataReference> MetadataReferenceProvider();
+}

--- a/src/NEsper.Common/common/client/artifact/MetadataReferenceProviderExtensions.cs
+++ b/src/NEsper.Common/common/client/artifact/MetadataReferenceProviderExtensions.cs
@@ -4,7 +4,7 @@ using com.espertech.esper.common.@internal.util;
 using com.espertech.esper.compat;
 using com.espertech.esper.compat.collections;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
 

--- a/src/NEsper.Common/common/client/artifact/MetadataReferenceProviderExtensions.cs
+++ b/src/NEsper.Common/common/client/artifact/MetadataReferenceProviderExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+using com.espertech.esper.common.@internal.util;
+using com.espertech.esper.compat;
+using com.espertech.esper.compat.collections;
+
+#if NETCORE
+using System.Runtime.Loader;
+#endif
+
+using com.espertech.esper.container;
+
+using Microsoft.CodeAnalysis;
+
+namespace com.espertech.esper.common.client.artifact
+{
+    public static class MetadataReferenceProviderExtensions
+    {
+        public static MetadataReferenceProvider MetadataReferenceProvider(this IContainer container)
+        {
+            container.CheckContainer();
+
+            lock (container) {
+                if (container.DoesNotHave<MetadataReferenceProvider>()) {
+                    container.Register<MetadataReferenceProvider>(Array.Empty<MetadataReference>, Lifespan.Singleton);
+                }
+            }
+
+            return container.Resolve<MetadataReferenceProvider>();
+        }
+    }
+}

--- a/src/NEsper.Common/common/client/artifact/MetadataReferenceResolver.cs
+++ b/src/NEsper.Common/common/client/artifact/MetadataReferenceResolver.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using com.espertech.esper.common.@internal.util;
+using com.espertech.esper.compat;
+using com.espertech.esper.compat.collections;
+
+#if NETCORE
+using System.Runtime.Loader;
+#endif
+
+using com.espertech.esper.container;
+
+using Microsoft.CodeAnalysis;
+
+namespace com.espertech.esper.common.client.artifact
+{
+    public delegate MetadataReference MetadataReferenceResolver(Assembly assembly);
+}

--- a/src/NEsper.Common/common/client/artifact/MetadataReferenceResolver.cs
+++ b/src/NEsper.Common/common/client/artifact/MetadataReferenceResolver.cs
@@ -6,7 +6,7 @@ using com.espertech.esper.common.@internal.util;
 using com.espertech.esper.compat;
 using com.espertech.esper.compat.collections;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
 

--- a/src/NEsper.Common/common/client/artifact/MetadataReferenceResolverExtensions.cs
+++ b/src/NEsper.Common/common/client/artifact/MetadataReferenceResolverExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System.Reflection;
+
+using com.espertech.esper.container;
+
+using Microsoft.CodeAnalysis;
+
+namespace com.espertech.esper.common.client.artifact
+{
+    public static class MetadataReferenceResolverExtensions
+    {
+        /// <summary>
+        /// Gets a metadata reference from an assembly.  This method provides no caching of the metadata
+        /// reference.
+        /// </summary>
+        /// <param name="assembly"></param>
+        /// <returns>a metadata reference for the requested assembly</returns>
+        public static MetadataReference GetMetadataReference(Assembly assembly)
+        {
+            return string.IsNullOrEmpty(assembly.Location) ? null : MetadataReference.CreateFromFile(assembly.Location);
+        }
+
+        /// <summary>
+        /// Retrieves an instance of the MetadataReferenceResolver.  If none has been registered, this method
+        /// will return the default resolver.
+        /// </summary>
+        /// <param name="container"></param>
+        /// <returns></returns>
+        public static MetadataReferenceResolver MetadataReferenceResolver(this IContainer container)
+        {
+            container.CheckContainer();
+
+            lock (container) {
+                if (container.DoesNotHave<MetadataReferenceResolver>()) {
+                    return GetMetadataReference;
+                }
+            }
+
+            return container.Resolve<MetadataReferenceResolver>();
+        }
+    }
+}

--- a/src/NEsper.Common/common/client/configuration/compiler/ConfigurationCompiler.cs
+++ b/src/NEsper.Common/common/client/configuration/compiler/ConfigurationCompiler.cs
@@ -106,7 +106,7 @@ namespace com.espertech.esper.common.client.configuration.compiler
         /// <summary>
         /// Returns true if the compiler should set optimization to debug.
         /// </summary>
-        public bool IsDebugOptimization { get; private set; }
+        public bool IsDebugOptimization { get; set; }
 
         /// <summary>
         ///     Returns the expression-related settings for compiler.

--- a/src/NEsper.Common/common/internal/epl/fafquery/querymethod/FAFQueryMethodSelectExecNoContextJoin.cs
+++ b/src/NEsper.Common/common/internal/epl/fafquery/querymethod/FAFQueryMethodSelectExecNoContextJoin.cs
@@ -19,6 +19,7 @@ using com.espertech.esper.common.@internal.epl.join.@base;
 using com.espertech.esper.common.@internal.epl.resultset.core;
 using com.espertech.esper.common.@internal.@event.core;
 using com.espertech.esper.common.@internal.view.core;
+using com.espertech.esper.compat.collections;
 
 using static com.espertech.esper.common.@internal.epl.fafquery.querymethod.FAFQueryMethodSelectExecUtil;
 
@@ -90,7 +91,10 @@ namespace com.espertech.esper.common.@internal.epl.fafquery.querymethod
                     agentInstanceContext);
             }
 
-            UniformPair<EventBean[]> results = resultSetProcessor.ProcessJoinResult(result.First, null, true);
+            UniformPair<EventBean[]> results = resultSetProcessor.ProcessJoinResult(
+                result.First,
+                EmptySet<MultiKeyArrayOfKeys<EventBean>>.Instance,
+                true);
 
             EventBean[] distinct = EventBeanUtility.GetDistinctByProp(results?.First, select.DistinctKeyGetter);
 

--- a/src/NEsper.Common/common/internal/epl/join/base/JoinSetComposerPrototypeGeneral.cs
+++ b/src/NEsper.Common/common/internal/epl/join/base/JoinSetComposerPrototypeGeneral.cs
@@ -112,7 +112,7 @@ namespace com.espertech.esper.common.@internal.epl.join.@base
                             streamJoinAnalysisResult,
                             agentInstanceContext);
                         if (virtualDWView != null) {
-                            index = VirtualDWQueryPlanUtil.GetJoinIndexTable(items.Get(entry.Key), virtualDWView);
+                            index = VirtualDWQueryPlanUtil.GetJoinIndexTable(items.Get(entry.Key));
                         }
                         else {
                             index = EventTableUtil.BuildIndex(

--- a/src/NEsper.Common/common/internal/epl/virtualdw/VirtualDWEventTable.cs
+++ b/src/NEsper.Common/common/internal/epl/virtualdw/VirtualDWEventTable.cs
@@ -24,14 +24,12 @@ namespace com.espertech.esper.common.@internal.epl.virtualdw
             bool unique,
             IList<VirtualDataWindowLookupFieldDesc> hashAccess,
             IList<VirtualDataWindowLookupFieldDesc> btreeAccess,
-            EventTableOrganization organization,
-            VirtualDWView virtualDwViewMayNull)
+            EventTableOrganization organization)
         {
             IsUnique = unique;
             HashAccess = Collections.ReadonlyList(hashAccess);
             BtreeAccess = Collections.ReadonlyList(btreeAccess);
             Organization = organization;
-            VirtualDWViewMayNull = virtualDwViewMayNull;
         }
 
         public IList<VirtualDataWindowLookupFieldDesc> HashAccess { get; }
@@ -80,9 +78,7 @@ namespace com.espertech.esper.common.@internal.epl.virtualdw
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return VirtualDWViewMayNull != null
-                ? VirtualDWViewMayNull.VirtualDataWindow.GetEnumerator()
-                : GetEnumerator();
+            return EnumerationHelper.Empty<EventBean>();
         }
 
         public bool IsEmpty => true;

--- a/src/NEsper.Common/common/internal/epl/virtualdw/VirtualDWQueryPlanUtil.cs
+++ b/src/NEsper.Common/common/internal/epl/virtualdw/VirtualDWQueryPlanUtil.cs
@@ -25,8 +25,7 @@ namespace com.espertech.esper.common.@internal.epl.virtualdw
         public static Pair<IndexMultiKey, VirtualDWEventTable> GetSubordinateQueryDesc(
             bool unique,
             IndexedPropDesc[] hashedProps,
-            IndexedPropDesc[] btreeProps,
-            VirtualDWView virtualDWView)
+            IndexedPropDesc[] btreeProps)
         {
             IList<VirtualDataWindowLookupFieldDesc> hashFields = new List<VirtualDataWindowLookupFieldDesc>();
             foreach (var hashprop in hashedProps) {
@@ -43,12 +42,12 @@ namespace com.espertech.esper.common.@internal.epl.virtualdw
                     new VirtualDataWindowLookupFieldDesc(btreeprop.IndexPropName, null, btreeprop.CoercionType));
             }
 
-            var eventTable = new VirtualDWEventTable(unique, hashFields, btreeFields, TABLE_ORGANIZATION, virtualDWView);
+            var eventTable = new VirtualDWEventTable(unique, hashFields, btreeFields, TABLE_ORGANIZATION);
             var imk = new IndexMultiKey(unique, hashedProps, btreeProps, null);
             return new Pair<IndexMultiKey, VirtualDWEventTable>(imk, eventTable);
         }
 
-        public static EventTable GetJoinIndexTable(QueryPlanIndexItem queryPlanIndexItem, VirtualDWView virtualDWView)
+        public static EventTable GetJoinIndexTable(QueryPlanIndexItem queryPlanIndexItem)
         {
             IList<VirtualDataWindowLookupFieldDesc> hashFields = new List<VirtualDataWindowLookupFieldDesc>();
             var count = 0;
@@ -78,7 +77,7 @@ namespace com.espertech.esper.common.@internal.epl.virtualdw
                 }
             }
 
-            return new VirtualDWEventTable(false, hashFields, btreeFields, TABLE_ORGANIZATION, virtualDWView);
+            return new VirtualDWEventTable(false, hashFields, btreeFields, TABLE_ORGANIZATION);
         }
 
         public static Pair<IndexMultiKey, EventTable> GetFireAndForgetDesc(
@@ -100,7 +99,7 @@ namespace com.espertech.esper.common.@internal.epl.virtualdw
                 btreeIndexedFields.Add(new IndexedPropDesc(btreeprop, eventType.GetPropertyType(btreeprop)));
             }
 
-            var noopTable = new VirtualDWEventTable(false, hashFields, btreeFields, TABLE_ORGANIZATION, null);
+            var noopTable = new VirtualDWEventTable(false, hashFields, btreeFields, TABLE_ORGANIZATION);
             var imk = new IndexMultiKey(false, hashIndexedFields, btreeIndexedFields, null);
 
             return new Pair<IndexMultiKey, EventTable>(imk, noopTable);

--- a/src/NEsper.Common/common/internal/epl/virtualdw/VirtualDWViewImpl.cs
+++ b/src/NEsper.Common/common/internal/epl/virtualdw/VirtualDWViewImpl.cs
@@ -87,8 +87,7 @@ namespace com.espertech.esper.common.@internal.epl.virtualdw
             Pair<IndexMultiKey, VirtualDWEventTable> tableVW = VirtualDWQueryPlanUtil.GetSubordinateQueryDesc(
                 false,
                 subordTableFactory.IndexHashedProps,
-                subordTableFactory.IndexBtreeProps,
-                this);
+                subordTableFactory.IndexBtreeProps);
             VirtualDWEventTable noopTable = tableVW.Second;
             for (int i = 0; i < noopTable.BtreeAccess.Count; i++) {
                 string opRange = subordTableFactory.RangeEvals[i].Type.StringOp();

--- a/src/NEsper.Common/common/internal/event/map/MapEventBeanArrayPropertyGetter.cs
+++ b/src/NEsper.Common/common/internal/event/map/MapEventBeanArrayPropertyGetter.cs
@@ -38,9 +38,6 @@ namespace com.espertech.esper.common.@internal.@event.map
         {
             this.propertyName = propertyName;
             this.underlyingType = underlyingType;
-            if (underlyingType.Name == "MyEvent") {
-                Console.WriteLine("MapEventBeanArrayPropertyGetter: ctor");
-            }
         }
 
         public object GetMap(IDictionary<string, object> map)

--- a/src/NEsper.Common/common/internal/util/AssemblyLoadContextExtensions.cs
+++ b/src/NEsper.Common/common/internal/util/AssemblyLoadContextExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
 

--- a/src/NEsper.Common/common/internal/util/SerializerUtil.cs
+++ b/src/NEsper.Common/common/internal/util/SerializerUtil.cs
@@ -21,8 +21,8 @@ namespace com.espertech.esper.common.@internal.util
         /// <returns>byte array</returns>
         public static byte[] ObjectToByteArr(object underlying)
         {
-            return SerializerFactory.Serialize(
-                new[] {SerializerFactory.OBJECT_SERIALIZER},
+            return SerializerFactory.Instance.Serialize(
+                new[] {SerializerFactory.Instance.OBJECT_SERIALIZER},
                 new[] {underlying});
         }
 
@@ -35,10 +35,10 @@ namespace com.espertech.esper.common.@internal.util
                 return null;
             }
 
-            return SerializerFactory.Deserialize(
+            return SerializerFactory.Instance.Deserialize(
                 1,
                 bytes,
-                new[] {SerializerFactory.OBJECT_SERIALIZER})[0];
+                new[] {SerializerFactory.Instance.OBJECT_SERIALIZER})[0];
         }
 
         public static object ByteArrBase64ToObject(string s)

--- a/src/NEsper.Common/common/internal/util/TypeHelper.cs
+++ b/src/NEsper.Common/common/internal/util/TypeHelper.cs
@@ -15,7 +15,7 @@ using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
 
@@ -2078,7 +2078,7 @@ namespace com.espertech.esper.common.@internal.util
         {
             IEnumerable<Assembly> assemblySearchPath = AssemblySearchPath?.Invoke();
             if (assemblySearchPath == null) {
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
                 assemblySearchPath = AssemblyLoadContext.Default.Assemblies.ToList();
 #else
                 assemblySearchPath = AppDomain.CurrentDomain.GetAssemblies();

--- a/src/NEsper.Common/container/ContainerImpl.cs
+++ b/src/NEsper.Common/container/ContainerImpl.cs
@@ -142,6 +142,12 @@ namespace com.espertech.esper.container
             return _container.Kernel.HasComponent(typeof(T));
         }
 
+        public bool Has<T>(string name)
+        {
+            CheckDisposed();
+            return _container.Kernel.HasComponent(name);
+        }
+        
         public bool Has(Type serviceType)
         {
             CheckDisposed();

--- a/src/NEsper.Common/container/ContainerInitializer.cs
+++ b/src/NEsper.Common/container/ContainerInitializer.cs
@@ -105,6 +105,7 @@ namespace com.espertech.esper.container
             //if (container.DoesNotHave<IConfigurationParser>())
             //    container.Register<IConfigurationParser, ConfigurationParser>(
             //        Lifespan.Transient);
+            
             if (container.DoesNotHave<TypeResolverProvider>())
                 container.Register<TypeResolverProvider>(
                     ic => new ArtifactTypeResolverProvider(ic),

--- a/src/NEsper.Common/container/ContainerInitializer.cs
+++ b/src/NEsper.Common/container/ContainerInitializer.cs
@@ -9,7 +9,7 @@
 using System;
 using System.Linq;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
 
@@ -101,7 +101,7 @@ namespace com.espertech.esper.container
                     ic => DefaultResourceManager(), Lifespan.Singleton);
             if (container.DoesNotHave<ITimerFactory>())
                 container.Register<ITimerFactory>(
-                    ic => new SystemTimerFactory(), Lifespan.Singleton);
+                    ic => new SimpleTimerFactory(), Lifespan.Singleton);
             //if (container.DoesNotHave<IConfigurationParser>())
             //    container.Register<IConfigurationParser, ConfigurationParser>(
             //        Lifespan.Transient);

--- a/src/NEsper.Compat/compat/AssemblyResolver.cs
+++ b/src/NEsper.Compat/compat/AssemblyResolver.cs
@@ -1,0 +1,19 @@
+﻿///////////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2006-2019 Esper Team. All rights reserved.                           /
+// http://esper.codehaus.org                                                          /
+// ---------------------------------------------------------------------------------- /
+// The software in this package is published under the terms of the GPL license       /
+// a copy of which has been included with this distribution in the license.txt file.  /
+///////////////////////////////////////////////////////////////////////////////////////
+
+using System.Reflection;
+
+namespace com.espertech.esper.compat
+{
+    /// <summary>
+    /// AssemblyResolver provides resolution of assemblies that may or may not be materialized into the process space.
+    /// <param name="assemblyName">Name of the assembly.</param>
+    /// <returns></returns>
+    /// </summary>
+    public delegate Assembly AssemblyResolver(AssemblyName assemblyName);
+}

--- a/src/NEsper.Compat/compat/HighResolutionTimeProvider.cs
+++ b/src/NEsper.Compat/compat/HighResolutionTimeProvider.cs
@@ -17,7 +17,7 @@ namespace com.espertech.esper.compat
     {
         public static readonly HighResolutionTimeProvider Instance = new HighResolutionTimeProvider();
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
         public long CurrentTime => DateTimeHelper.CurrentTimeNanos;
 #else
         [DllImport("Kernel32.dll")]

--- a/src/NEsper.Compat/compat/diagnostics/PerformanceMetricsHelper.cs
+++ b/src/NEsper.Compat/compat/diagnostics/PerformanceMetricsHelper.cs
@@ -15,7 +15,7 @@ namespace com.espertech.esper.compat.diagnostics
     {
         public static ProcessThread GetProcessThread()
         {
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
             return null;
 #else
             var processThread = ProcessThreadHelper.GetProcessThread();
@@ -30,7 +30,7 @@ namespace com.espertech.esper.compat.diagnostics
 
         public static void ExecCpuBound(Func<PerformanceExecutionContext, bool> cpuAction)
         {
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
             throw new NotSupportedException("cpu bound execution not supported");
 #else
             var executionContext = new PerformanceExecutionContext();

--- a/src/NEsper.Compat/compat/diagnostics/PerformanceMetricsHelper.cs
+++ b/src/NEsper.Compat/compat/diagnostics/PerformanceMetricsHelper.cs
@@ -40,7 +40,6 @@ namespace com.espertech.esper.compat.diagnostics
                 throw new IllegalStateException("unable to acquire process thread; check platform");
             }
 
-            Console.WriteLine($"processthread: {processThread}");
             executionContext.InitialUserTime = processThread.UserProcessorTime;
             executionContext.InitialPrivTime = processThread.PrivilegedProcessorTime;
             executionContext.InitialTotalTime = processThread.TotalProcessorTime;

--- a/src/NEsper.Compat/compat/diagnostics/ProcessThreadHelper.cs
+++ b/src/NEsper.Compat/compat/diagnostics/ProcessThreadHelper.cs
@@ -16,7 +16,7 @@ namespace com.espertech.esper.compat.diagnostics
 {
     public static class ProcessThreadHelper
     {
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 #else
         [DllImport("Kernel32.dll", EntryPoint = "GetCurrentThreadId", ExactSpelling = true)]
         public static extern int GetCurrentWin32ThreadId();
@@ -24,7 +24,7 @@ namespace com.espertech.esper.compat.diagnostics
         
         public static ProcessThread GetProcessThread()
         {
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
             return null;
 #else
             return GetProcessThread(GetCurrentWin32ThreadId());

--- a/src/NEsper.Compat/compat/timers/HighResolutionTimer.cs
+++ b/src/NEsper.Compat/compat/timers/HighResolutionTimer.cs
@@ -15,8 +15,6 @@ using com.espertech.esper.compat.logging;
 
 namespace com.espertech.esper.compat.timers
 {
-#if NETCORE
-#else
     /// <summary>
     /// Windows timers are based on the system timer.  The system timer runs at a
     /// frequency of about 50-60 hz depending on your machine.  This presents a 
@@ -271,5 +269,4 @@ namespace com.espertech.esper.compat.timers
 
         private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
     }
-#endif
 }

--- a/src/NEsper.Compat/compat/timers/HighResolutionTimerFactory.cs
+++ b/src/NEsper.Compat/compat/timers/HighResolutionTimerFactory.cs
@@ -11,7 +11,7 @@ using System.Threading;
 
 namespace com.espertech.esper.compat.timers
 {
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 #else
     /// <summary>
     /// Implementation of the TimerFactory that uses the HighResolutionTimer.

--- a/src/NEsper.Compat/compat/timers/PeriodicTimerFactory.cs
+++ b/src/NEsper.Compat/compat/timers/PeriodicTimerFactory.cs
@@ -14,7 +14,6 @@ using com.espertech.esper.compat.logging;
 
 namespace com.espertech.esper.compat.timers
 {
-#if NET6
     public class PeriodicTimerFactory : ITimerFactory
     {
         public ITimer CreateTimer(
@@ -47,24 +46,18 @@ namespace com.espertech.esper.compat.timers
 
             async void ExecuteTimer()
             {
-                Console.WriteLine("Starting");
-                
                 if (_offset != TimeSpan.Zero) {
                     await Task.Delay(_offset);
-                    Console.WriteLine("ExecuteTimer: Delay Fire: {0}", _offset);
                     _timerCallback(this);
                 }
 
                 while (_isRunning && await _timer.WaitForNextTickAsync()) {
-                    Console.WriteLine("ExecuteTimer: Fire");
                     _timerCallback(this);
                 }
             }
 
             public void Dispose()
             {
-                Console.WriteLine("Dispose");
-                
                 _isRunning = false;
                 _timer?.Dispose();
                 _timer = null;
@@ -75,5 +68,4 @@ namespace com.espertech.esper.compat.timers
 
         private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
     }
-#endif
 }

--- a/src/NEsper.Compat/compat/timers/PeriodicTimerFactory.cs
+++ b/src/NEsper.Compat/compat/timers/PeriodicTimerFactory.cs
@@ -14,6 +14,7 @@ using com.espertech.esper.compat.logging;
 
 namespace com.espertech.esper.compat.timers
 {
+#if NET6_0_OR_GREATER
     public class PeriodicTimerFactory : ITimerFactory
     {
         public ITimer CreateTimer(
@@ -68,4 +69,5 @@ namespace com.espertech.esper.compat.timers
 
         private static readonly ILog Log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
     }
+#endif
 }

--- a/src/NEsper.Compat/compat/timers/SimpleTimerFactory.cs
+++ b/src/NEsper.Compat/compat/timers/SimpleTimerFactory.cs
@@ -27,7 +27,7 @@ namespace com.espertech.esper.compat.timers
             return new SimpleTimer(timerCallback, offsetInMillis, intervalInMillis);
         }
 
-        private class SimpleTimer : ITimer
+        public class SimpleTimer : ITimer
         {
             private Timer _timer;
 

--- a/src/NEsper.Compat/compat/timers/SystemTimerFactory.cs
+++ b/src/NEsper.Compat/compat/timers/SystemTimerFactory.cs
@@ -99,13 +99,8 @@ namespace com.espertech.esper.compat.timers
         {
             lock (_baseTimerLock)
             {
-                if (_baseTimer == null)
-                {
-#if NETCORE
-                    _baseTimer = new HarmonicTimer(OnTimerEvent);
-#else
+                if (_baseTimer == null) {
                     _baseTimer = new HighResolutionTimer(OnTimerEvent, null, 0, 10);
-#endif
                 }
             }
         }

--- a/src/NEsper.Compat/compat/timers/TimerFactory.cs
+++ b/src/NEsper.Compat/compat/timers/TimerFactory.cs
@@ -25,15 +25,8 @@ namespace com.espertech.esper.compat.timers
         {
             get
             {
-                lock( factoryLock )
-                {
-                    if (defaultTimerFactory == null)
-                    {
-                        // use the system timer factory unless explicitly instructed
-                        // to do otherwise.
-
-                        defaultTimerFactory = new SystemTimerFactory();
-                    }
+                lock( factoryLock ) {
+                    defaultTimerFactory ??= new SimpleTimerFactory();
                 }
 
                 return defaultTimerFactory;

--- a/src/NEsper.Compiler/client/CoreAssemblyProvider.cs
+++ b/src/NEsper.Compiler/client/CoreAssemblyProvider.cs
@@ -1,0 +1,19 @@
+﻿///////////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2006-2019 Esper Team. All rights reserved.                           /
+// http://esper.codehaus.org                                                          /
+// ---------------------------------------------------------------------------------- /
+// The software in this package is published under the terms of the GPL license       /
+// a copy of which has been included with this distribution in the license.txt file.  /
+///////////////////////////////////////////////////////////////////////////////////////
+
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace com.espertech.esper.compiler.client
+{
+    /// <summary>
+    /// CoreAssemblyProvider determines what assemblies should be provided to the compiler
+    /// as part of the compilation and linking process.
+    /// </summary>
+    public delegate IEnumerable<Assembly> CoreAssemblyProvider();
+}

--- a/src/NEsper.Compiler/client/CoreAssemblyProviderExtensions.cs
+++ b/src/NEsper.Compiler/client/CoreAssemblyProviderExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Loader;
+
+using com.espertech.esper.container;
+
+namespace com.espertech.esper.compiler.client
+{
+    public static class CoreAssemblyProviderExtensions
+    {
+        /// <summary>
+        /// Provides the assemblies should be provided to the compiler as part of the compilation and linking process.
+        /// </summary>
+        public static IEnumerable<Assembly> GetCoreAssemblies()
+        {
+#if NETCORE
+            return AssemblyLoadContext.Default.Assemblies;
+#else
+            return AppDomain.CurrentDomain.GetAssemblies();
+#endif
+        }
+
+        /// <summary>
+        /// Retrieves an instance of the CoreAssemblyProvider.  If none has been registered, this method
+        /// will return the default resolver.
+        /// </summary>
+        /// <param name="container">the IoC container</param>
+        /// <returns></returns>
+        public static CoreAssemblyProvider CoreAssemblyProvider(this IContainer container)
+        {
+            container.CheckContainer();
+
+            lock (container) {
+                if (container.DoesNotHave<CoreAssemblyProvider>()) {
+                    return GetCoreAssemblies;
+                }
+            }
+
+            return container.Resolve<CoreAssemblyProvider>();
+        }
+    }
+}

--- a/src/NEsper.Compiler/client/CoreAssemblyProviderExtensions.cs
+++ b/src/NEsper.Compiler/client/CoreAssemblyProviderExtensions.cs
@@ -13,7 +13,7 @@ namespace com.espertech.esper.compiler.client
         /// </summary>
         public static IEnumerable<Assembly> GetCoreAssemblies()
         {
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
             return AssemblyLoadContext.Default.Assemblies;
 #else
             return AppDomain.CurrentDomain.GetAssemblies();

--- a/src/NEsper.Compiler/client/util/EPCompiledIOUtil.cs
+++ b/src/NEsper.Compiler/client/util/EPCompiledIOUtil.cs
@@ -12,7 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
 
@@ -50,7 +50,7 @@ namespace com.espertech.esper.compiler.client.util
 
 		private static Assembly LoadAssembly(byte[] image)
 		{
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 			var assemblyLoadContext = AssemblyLoadContext.CurrentContextualReflectionContext;
 			if (assemblyLoadContext == null) {
 				assemblyLoadContext = AssemblyLoadContext.Default;

--- a/src/NEsper.Compiler/internal/util/CompileCallable.cs
+++ b/src/NEsper.Compiler/internal/util/CompileCallable.cs
@@ -46,6 +46,7 @@ namespace com.espertech.esper.compiler.@internal.util
 					.RoslynCompiler()
 					.WithMetaDataReferences(repository.AllMetadataReferences)
 					.WithMetaDataReferences(container.MetadataReferenceProvider()?.Invoke())
+					.WithDebugOptimization(_compileTimeServices.Configuration.Compiler.IsDebugOptimization)
 					.WithCodeLogging(_compileTimeServices.Configuration.Compiler.Logging.IsEnableCode)
 					.WithCodeAuditDirectory(_compileTimeServices.Configuration.Compiler.Logging.AuditDirectory)
 					.WithCodegenClasses(_compilableItem.Classes);

--- a/src/NEsper.Compiler/internal/util/CompileCallable.cs
+++ b/src/NEsper.Compiler/internal/util/CompileCallable.cs
@@ -45,6 +45,7 @@ namespace com.espertech.esper.compiler.@internal.util
 				var compiler = container
 					.RoslynCompiler()
 					.WithMetaDataReferences(repository.AllMetadataReferences)
+					.WithMetaDataReferences(container.MetadataReferenceProvider()?.Invoke())
 					.WithCodeLogging(_compileTimeServices.Configuration.Compiler.Logging.IsEnableCode)
 					.WithCodeAuditDirectory(_compileTimeServices.Configuration.Compiler.Logging.AuditDirectory)
 					.WithCodegenClasses(_compilableItem.Classes);

--- a/src/NEsper.Compiler/internal/util/CompilerHelperFAFProvider.cs
+++ b/src/NEsper.Compiler/internal/util/CompilerHelperFAFProvider.cs
@@ -317,6 +317,7 @@ namespace com.espertech.esper.compiler.@internal.util
             var compiler = container
                 .RoslynCompiler()
                 .WithMetaDataReferences(artifactRepository.AllMetadataReferences)
+                .WithMetaDataReferences(container.MetadataReferenceProvider()?.Invoke())
                 .WithCodeLogging(compileTimeServices.Configuration.Compiler.Logging.IsEnableCode)
                 .WithCodeAuditDirectory(compileTimeServices.Configuration.Compiler.Logging.AuditDirectory)
                 .WithCodegenClasses(new List<CodegenClass>() { clazz });

--- a/src/NEsper.Compiler/internal/util/CompilerHelperFAFProvider.cs
+++ b/src/NEsper.Compiler/internal/util/CompilerHelperFAFProvider.cs
@@ -318,6 +318,7 @@ namespace com.espertech.esper.compiler.@internal.util
                 .RoslynCompiler()
                 .WithMetaDataReferences(artifactRepository.AllMetadataReferences)
                 .WithMetaDataReferences(container.MetadataReferenceProvider()?.Invoke())
+                .WithDebugOptimization(compileTimeServices.Configuration.Compiler.IsDebugOptimization)
                 .WithCodeLogging(compileTimeServices.Configuration.Compiler.Logging.IsEnableCode)
                 .WithCodeAuditDirectory(compileTimeServices.Configuration.Compiler.Logging.AuditDirectory)
                 .WithCodegenClasses(new List<CodegenClass>() { clazz });

--- a/src/NEsper.Compiler/internal/util/CompilerHelperFAFQuery.cs
+++ b/src/NEsper.Compiler/internal/util/CompilerHelperFAFQuery.cs
@@ -64,6 +64,7 @@ namespace com.espertech.esper.compiler.@internal.util
             var compiler = container
                 .RoslynCompiler()
                 .WithMetaDataReferences(repository.AllMetadataReferences)
+                .WithMetaDataReferences(container.MetadataReferenceProvider()?.Invoke())
                 .WithCodeLogging(compileTimeServices.Configuration.Compiler.Logging.IsEnableCode)
                 .WithCodeAuditDirectory(compileTimeServices.Configuration.Compiler.Logging.AuditDirectory)
                 .WithCodegenClasses(classes);

--- a/src/NEsper.Compiler/internal/util/CompilerHelperFAFQuery.cs
+++ b/src/NEsper.Compiler/internal/util/CompilerHelperFAFQuery.cs
@@ -65,6 +65,7 @@ namespace com.espertech.esper.compiler.@internal.util
                 .RoslynCompiler()
                 .WithMetaDataReferences(repository.AllMetadataReferences)
                 .WithMetaDataReferences(container.MetadataReferenceProvider()?.Invoke())
+                .WithDebugOptimization(compileTimeServices.Configuration.Compiler.IsDebugOptimization)
                 .WithCodeLogging(compileTimeServices.Configuration.Compiler.Logging.IsEnableCode)
                 .WithCodeAuditDirectory(compileTimeServices.Configuration.Compiler.Logging.AuditDirectory)
                 .WithCodegenClasses(classes);

--- a/src/NEsper.Compiler/internal/util/CompilerHelperModuleProvider.cs
+++ b/src/NEsper.Compiler/internal/util/CompilerHelperModuleProvider.cs
@@ -464,6 +464,7 @@ namespace com.espertech.esper.compiler.@internal.util
                 .RoslynCompiler()
                 .WithMetaDataReferences(repository.AllMetadataReferences)
                 .WithMetaDataReferences(container.MetadataReferenceProvider()?.Invoke())
+                .WithDebugOptimization(compileTimeServices.Configuration.Compiler.IsDebugOptimization)
                 .WithCodeLogging(compileTimeServices.Configuration.Compiler.Logging.IsEnableCode)
                 .WithCodeAuditDirectory(compileTimeServices.Configuration.Compiler.Logging.AuditDirectory)
                 .WithCodegenClasses(new[] {clazz});

--- a/src/NEsper.Compiler/internal/util/CompilerHelperModuleProvider.cs
+++ b/src/NEsper.Compiler/internal/util/CompilerHelperModuleProvider.cs
@@ -463,6 +463,7 @@ namespace com.espertech.esper.compiler.@internal.util
             var compiler = container
                 .RoslynCompiler()
                 .WithMetaDataReferences(repository.AllMetadataReferences)
+                .WithMetaDataReferences(container.MetadataReferenceProvider()?.Invoke())
                 .WithCodeLogging(compileTimeServices.Configuration.Compiler.Logging.IsEnableCode)
                 .WithCodeAuditDirectory(compileTimeServices.Configuration.Compiler.Logging.AuditDirectory)
                 .WithCodegenClasses(new[] {clazz});

--- a/src/NEsper.Compiler/internal/util/CompilerHelperStatementProvider.cs
+++ b/src/NEsper.Compiler/internal/util/CompilerHelperStatementProvider.cs
@@ -350,6 +350,7 @@ namespace com.espertech.esper.compiler.@internal.util
                 var compiler = container
                     .RoslynCompiler()
                     .WithMetaDataReferences(artifactRepository.AllMetadataReferences)
+                    .WithMetaDataReferences(container.MetadataReferenceProvider()?.Invoke())
                     .WithCodeLogging(compileTimeServices.Configuration.Compiler.Logging.IsEnableCode)
                     .WithCodeAuditDirectory(compileTimeServices.Configuration.Compiler.Logging.AuditDirectory)
                     .WithCodegenClasses(sorted);

--- a/src/NEsper.Compiler/internal/util/CompilerHelperStatementProvider.cs
+++ b/src/NEsper.Compiler/internal/util/CompilerHelperStatementProvider.cs
@@ -351,6 +351,7 @@ namespace com.espertech.esper.compiler.@internal.util
                     .RoslynCompiler()
                     .WithMetaDataReferences(artifactRepository.AllMetadataReferences)
                     .WithMetaDataReferences(container.MetadataReferenceProvider()?.Invoke())
+                    .WithDebugOptimization(compileTimeServices.Configuration.Compiler.IsDebugOptimization)
                     .WithCodeLogging(compileTimeServices.Configuration.Compiler.Logging.IsEnableCode)
                     .WithCodeAuditDirectory(compileTimeServices.Configuration.Compiler.Logging.AuditDirectory)
                     .WithCodegenClasses(sorted);

--- a/src/NEsper.Compiler/internal/util/CompilerServicesImpl.cs
+++ b/src/NEsper.Compiler/internal/util/CompilerServicesImpl.cs
@@ -102,6 +102,7 @@ namespace com.espertech.esper.compiler.@internal.util
                 .RoslynCompiler()
                 .WithMetaDataReferences(repository.AllMetadataReferences)
                 .WithMetaDataReferences(container.MetadataReferenceProvider()?.Invoke())
+                .WithDebugOptimization(configuration.Compiler.IsDebugOptimization)
                 .WithCodeLogging(configuration.Compiler.Logging.IsEnableCode)
                 .WithCodeAuditDirectory(configuration.Compiler.Logging.AuditDirectory)
                 .WithSources(

--- a/src/NEsper.Compiler/internal/util/CompilerServicesImpl.cs
+++ b/src/NEsper.Compiler/internal/util/CompilerServicesImpl.cs
@@ -101,6 +101,7 @@ namespace com.espertech.esper.compiler.@internal.util
             var compiler = container
                 .RoslynCompiler()
                 .WithMetaDataReferences(repository.AllMetadataReferences)
+                .WithMetaDataReferences(container.MetadataReferenceProvider()?.Invoke())
                 .WithCodeLogging(configuration.Compiler.Logging.IsEnableCode)
                 .WithCodeAuditDirectory(configuration.Compiler.Logging.AuditDirectory)
                 .WithSources(

--- a/src/NEsper.Compiler/internal/util/CompilerVersion.cs
+++ b/src/NEsper.Compiler/internal/util/CompilerVersion.cs
@@ -10,6 +10,6 @@ namespace com.espertech.esper.compiler.@internal.util
 {
     public class CompilerVersion
     {
-        public const string COMPILER_VERSION = "8.5.6";
+        public const string COMPILER_VERSION = "8.5.7";
     }
 } // end of namespace

--- a/src/NEsper.Compiler/internal/util/RoslynCompiler.cs
+++ b/src/NEsper.Compiler/internal/util/RoslynCompiler.cs
@@ -12,7 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
 

--- a/src/NEsper.Compiler/internal/util/RoslynCompiler.cs
+++ b/src/NEsper.Compiler/internal/util/RoslynCompiler.cs
@@ -149,7 +149,17 @@ namespace com.espertech.esper.compiler.@internal.util
 
         public RoslynCompiler WithMetaDataReferences(IEnumerable<MetadataReference> metadataReferences)
         {
-            MetadataReferences = metadataReferences;
+            if (metadataReferences != null) {
+                if (MetadataReferences == null) {
+                    MetadataReferences = metadataReferences;
+                }
+                else {
+                    MetadataReferences = MetadataReferences
+                        .Concat(metadataReferences)
+                        .ToList();
+                }
+            }
+
             return this;
         }
         

--- a/src/NEsper.Compiler/internal/util/RoslynCompiler.cs
+++ b/src/NEsper.Compiler/internal/util/RoslynCompiler.cs
@@ -30,6 +30,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 using IContainer = com.espertech.esper.container.IContainer;
+using MetadataReferenceResolver = com.espertech.esper.common.client.artifact.MetadataReferenceResolver;
 
 namespace com.espertech.esper.compiler.@internal.util
 {
@@ -299,9 +300,10 @@ namespace com.espertech.esper.compiler.@internal.util
         
         public MetadataReference GetMetadataReference(Assembly assembly)
         {
-            if (!IsDynamicAssembly(assembly))
-                return MetadataReference.CreateFromFile(assembly.Location);
-        
+            if (!IsDynamicAssembly(assembly)) {
+                return Container.MetadataReferenceResolver().Invoke(assembly);
+            }
+
             return null;
         }
 

--- a/src/NEsper.Compiler/internal/util/Version.cs
+++ b/src/NEsper.Compiler/internal/util/Version.cs
@@ -11,7 +11,7 @@ namespace com.espertech.esper.compiler.@internal.util
     public class Version
     {
         public static string COMPILER_VERSION {
-            get => "8.5.6";
+            get => "8.5.7";
         }
     }
 } // end of namespace

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarBaseListener.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarBaseListener.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.6\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.7\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarBaseVisitor.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarBaseVisitor.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.6\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.7\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarLexer.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarLexer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.6\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.7\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarListener.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarListener.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.6\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.7\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarParser.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarParser.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.6\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.7\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarVisitor.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarVisitor.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.6\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.7\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Runtime/client/util/RuntimeVersion.cs
+++ b/src/NEsper.Runtime/client/util/RuntimeVersion.cs
@@ -19,7 +19,7 @@ namespace com.espertech.esper.runtime.client.util
         /// <summary>
         ///     Current runtime version.
         /// </summary>
-        public const string RUNTIME_VERSION = "8.5.6";
+        public const string RUNTIME_VERSION = "8.5.7";
 
         /// <summary>
         ///     Current runtime major version.

--- a/src/NEsper.Runtime/internal/kernel/service/DeployerHelperInitStatement.cs
+++ b/src/NEsper.Runtime/internal/kernel/service/DeployerHelperInitStatement.cs
@@ -10,7 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
 
@@ -61,7 +61,7 @@ namespace com.espertech.esper.runtime.@internal.kernel.service
 			// get module statements
 			IList<StatementProvider> statementResources;
 			try {
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 				if (Log.IsDebugEnabled) {
 					var assemblyLoadContext = AssemblyLoadContext.GetLoadContext(moduleProvider.ModuleProvider.GetType().Assembly);
 					Log.Debug("AssemblyLoadContext: {0}", assemblyLoadContext);

--- a/src/NEsper.Runtime/internal/kernel/service/DeployerRolloutArgs.cs
+++ b/src/NEsper.Runtime/internal/kernel/service/DeployerRolloutArgs.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
 

--- a/src/NEsper.Runtime/internal/kernel/service/EPDeploymentServiceImpl.cs
+++ b/src/NEsper.Runtime/internal/kernel/service/EPDeploymentServiceImpl.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Loader;
 
 using com.espertech.esper.common.client.artifact;

--- a/src/NEsper.Runtime/internal/namedwindow/NamedWindowDispatchServiceImpl.cs
+++ b/src/NEsper.Runtime/internal/namedwindow/NamedWindowDispatchServiceImpl.cs
@@ -95,7 +95,6 @@ namespace com.espertech.esper.runtime.@internal.namedwindow
                         dispatchesTL.Current.AddAll(dispatchesTL.Dispatches);
                         dispatchesTL.Dispatches.Clear();
                         ProcessDispatches(dispatchesTL.Current, dispatchesTL.Work, dispatchesTL.DispatchesPerStmt);
-                        Console.WriteLine("{0}", dispatchesTL.Current.Count);
                     }
                     catch (EPException) {
                         throw;

--- a/tst/NEsper.Common.Tests/internal/util/TestSerializerFactory.cs
+++ b/tst/NEsper.Common.Tests/internal/util/TestSerializerFactory.cs
@@ -65,14 +65,15 @@ namespace com.espertech.esper.common.@internal.util
                 classes[i] = expected.GetType();
             }
 
-            var serializers = SerializerFactory.GetSerializers(classes);
-            var bytes = SerializerFactory.Serialize(serializers, expected);
+            var serializerFactory = SerializerFactory.Instance;
+            var serializers = serializerFactory.GetSerializers(classes);
+            var bytes = serializerFactory.Serialize(serializers, expected);
 
-            var result = SerializerFactory.Deserialize(expected.Length, bytes, serializers);
+            var result = serializerFactory.Deserialize(expected.Length, bytes, serializers);
             EPAssertionUtil.AssertEqualsExactOrder(expected, result);
 
             // null values are simply not serialized
-            bytes = SerializerFactory.Serialize(new[] { SerializerFactory.GetSerializer(typeof(int?)) }, new object[] { null });
+            bytes = serializerFactory.Serialize(new[] { serializerFactory.GetSerializer(typeof(int?)) }, new object[] { null });
             Assert.AreEqual(0, bytes.Length);
         }
     }

--- a/tst/NEsper.Regression.Runner/runner/RegressionSession.cs
+++ b/tst/NEsper.Regression.Runner/runner/RegressionSession.cs
@@ -10,7 +10,7 @@ using System;
 using System.IO;
 using System.Linq;
 
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime;
 using System.Runtime.Loader;
 #endif
@@ -75,7 +75,7 @@ namespace com.espertech.esper.regressionrun.runner
             Runtime = null;
         }
         
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
         public class DisposableAssemblyLoadContext : AssemblyLoadContext,
             IDisposable
         {

--- a/tst/NEsper.Regression.Runner/suite/client/TestSuiteClientRuntime.cs
+++ b/tst/NEsper.Regression.Runner/suite/client/TestSuiteClientRuntime.cs
@@ -314,10 +314,10 @@ namespace com.espertech.esper.regressionrun.suite.client
             }
 
             [Test, RunInApplicationDomain]
-            public void WithingleModuleTwoStatementsNoDep() => RegressionRunner.Run(_session, ClientRuntimeStatementName.WithingleModuleTwoStatementsNoDep());
+            public void WithSingleModuleTwoStatementsNoDep() => RegressionRunner.Run(_session, ClientRuntimeStatementName.WithSingleModuleTwoStatementsNoDep());
 
             [Test, RunInApplicationDomain]
-            public void WithtatementNameDuplicate() => RegressionRunner.Run(_session, ClientRuntimeStatementName.WithtatementNameDuplicate());
+            public void WithStatementNameDuplicate() => RegressionRunner.Run(_session, ClientRuntimeStatementName.WithStatementNameDuplicate());
         }
 
         /// <summary>
@@ -334,9 +334,11 @@ namespace com.espertech.esper.regressionrun.suite.client
             }
 
             [Test, RunInApplicationDomain]
+            [Parallelizable(ParallelScope.None)]
             public void WithPerformanceSynthetic() => RegressionRunner.Run(_session, ClientRuntimeSubscriber.WithPerformanceSynthetic());
 
             [Test, RunInApplicationDomain]
+            [Parallelizable(ParallelScope.None)]
             public void WithPerformanceSyntheticUndelivered() => RegressionRunner.Run(_session, ClientRuntimeSubscriber.WithPerformanceSyntheticUndelivered());
 
             [Test, RunInApplicationDomain]

--- a/tst/NEsper.Regression.Runner/suite/expr/TestSuiteExprEnum.cs
+++ b/tst/NEsper.Regression.Runner/suite/expr/TestSuiteExprEnum.cs
@@ -91,6 +91,7 @@ namespace com.espertech.esper.regressionrun.suite.expr
         }
 
         [Test]
+        [Parallelizable(ParallelScope.None)]
         public void TestExprEnumNamedWindowPerformance()
         {
             RegressionRunner.Run(_session, new ExprEnumNamedWindowPerformance());

--- a/tst/NEsper.Regression/NEsperSetup.cs
+++ b/tst/NEsper.Regression/NEsperSetup.cs
@@ -25,7 +25,7 @@ namespace com.espertech.esper.regressionlib
         [OneTimeSetUp]
         public void RunBeforeAnyTests()
         {
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 #else
             //var clearScript = typeof(ScriptingEngineJScript);
 #endif

--- a/tst/NEsper.Regression/suite/client/deploy/ClientDeployVersion.cs
+++ b/tst/NEsper.Regression/suite/client/deploy/ClientDeployVersion.cs
@@ -37,7 +37,7 @@ namespace com.espertech.esper.regressionlib.suite.client.deploy
 				EPCompiled compiled = EPCompiledIOUtil.Read(new File(file));
 
 				var versionMismatchMsg =
-					"Major or minor version of compiler and runtime mismatch; The runtime version is 8.5.6 and the compiler version of the compiled unit is 8.0.0";
+					"Major or minor version of compiler and runtime mismatch; The runtime version is 8.5.7 and the compiler version of the compiled unit is 8.0.0";
 				AssertMessage(
 					Assert.Throws<EPDeployDeploymentVersionException>(
 						() => env.Runtime.DeploymentService.Deploy(compiled)),
@@ -51,7 +51,7 @@ namespace com.espertech.esper.regressionlib.suite.client.deploy
 				AssertMessage(
 					Assert.Throws<EPException>(
 						() => env.Runtime.FireAndForgetService.ExecuteQuery(compiled)),
-					"Major or minor version of compiler and runtime mismatch; The runtime version is 8.5.6 and the compiler version of the compiled unit is 8.0.0");
+					"Major or minor version of compiler and runtime mismatch; The runtime version is 8.5.7 and the compiler version of the compiled unit is 8.0.0");
 #endif
 			}
 		}

--- a/tst/NEsper.Regression/suite/client/runtime/ClientRuntimeStatementName.cs
+++ b/tst/NEsper.Regression/suite/client/runtime/ClientRuntimeStatementName.cs
@@ -21,19 +21,19 @@ namespace com.espertech.esper.regressionlib.suite.client.runtime
         public static IList<RegressionExecution> Executions()
         {
             IList<RegressionExecution> execs = new List<RegressionExecution>();
-            WithtatementNameDuplicate(execs);
-            WithingleModuleTwoStatementsNoDep(execs);
+            WithStatementNameDuplicate(execs);
+            WithSingleModuleTwoStatementsNoDep(execs);
             return execs;
         }
 
-        public static IList<RegressionExecution> WithingleModuleTwoStatementsNoDep(IList<RegressionExecution> execs = null)
+        public static IList<RegressionExecution> WithSingleModuleTwoStatementsNoDep(IList<RegressionExecution> execs = null)
         {
             execs = execs ?? new List<RegressionExecution>();
             execs.Add(new ClientRuntimeSingleModuleTwoStatementsNoDep());
             return execs;
         }
 
-        public static IList<RegressionExecution> WithtatementNameDuplicate(IList<RegressionExecution> execs = null)
+        public static IList<RegressionExecution> WithStatementNameDuplicate(IList<RegressionExecution> execs = null)
         {
             execs = execs ?? new List<RegressionExecution>();
             execs.Add(new ClientRuntimeStatementNameDuplicate());

--- a/tst/NEsper.Regression/suite/expr/exprcore/ExprCoreLikeRegexp.cs
+++ b/tst/NEsper.Regression/suite/expr/exprcore/ExprCoreLikeRegexp.cs
@@ -190,7 +190,7 @@ public static IList<RegressionExecution> WithLikeRegexNumericAndNull(IList<Regre
 					"select TheString regexp \"*any*\" from SupportBean",
 					"Failed to validate select-clause expression 'TheString regexp \"*any*\"': " +
 					"Failed to compile regex pattern '*any*': " +
-#if NETCORE
+#if NETCOREAPP3_0_OR_GREATER
 					"Invalid pattern '*any*' at offset 1. Quantifier {x,y} following nothing."
 #else
 					"parsing \"*any*\" - Quantifier {x,y} following nothing."


### PR DESCRIPTION
# Overview

This hotfix is designed to address two deficiencies identified while using dynamically loaded assemblies (e.g., plugins)

* Addresses inability to load references from hidden libraries.
* Addresses inability to load assemblies unknown at runtime.

## MetadataReferenceProvider

The first issue is that the compiler is unaware of references for types you may want to use but are not visible (for any number of reasons).  To address this we've added a `MetadataReferenceProvider`.  It allows the program to provide additional MetadataReferences (required for Roslyn at runtime).

To provide your own, add a reference to the container.  Reference code:

```
        container.Register<MetadataReferenceProvider>(
            () => myMetadataReferences, Lifespan.Singleton);
```

This allows your code to provide a delegate that is called to get your MetadataReferences at compile time. 

## AssemblyResolver

The second issue is that at runtime, NEsper may reference libraries that were compiled using the aforementioned MetadataReferences.  These references may fail making the runtime fail.  .NET provides a mechanism for handling this associated with the `AssemblyLoadContext`, but `AssemblyLoadContext` initialization is deep in the `ArtifactRepository`.  You can use the `AssemblyResolver` (like the `TypeResolver`) to resolve an assembly at runtime if the `ArtifactRepository` fails to resolve an assembly.

```
container.Register<AssemblyResolver>(ic => myResolveAssembly, Lifespan.Singleton);
```

# Example

I modified the SmartTypeResolver I previously provided as follows:

```
public class SmartTypeResolver : TypeResolver, TypeRepository
{
    private readonly TypeResolver _parentTypeResolver;
    private readonly IDictionary<string, Type> _typeCache;
    private readonly IDictionary<string, Assembly> _assemblyCache;

    public SmartTypeResolver()
    {
        // use the default resolver for resolving types if the type
        // is not known to this resolver
        _parentTypeResolver = TypeResolverDefault.INSTANCE;
        // a cache that contains types that we are aware of but may not
        // be visible to the default type resolver
        _typeCache = new Dictionary<string, Type>();

        _assemblyCache = new Dictionary<string, Assembly>();
    }

    public IEnumerable<MetadataReference> MetadataReferences {
        get {
            return _typeCache.Values
                .Select(_ => _.Assembly)
                .Distinct()
                .Select(_ => MetadataReference.CreateFromFile(_.Location))
                .Distinct()
                .ToList();
        }
    }

    public void AddType(Type type)
    {
        _typeCache.TryAdd(type.FullName!, type);
        _assemblyCache.TryAdd(type.Assembly.GetName().Name, type.Assembly);
    }

    public Assembly ResolveAssembly(AssemblyName assemblyName)
    {
        _assemblyCache.TryGetValue(assemblyName.Name, out var assembly);
        return assembly;
    }
    
    public Type ResolveType(
        string typeName,
        bool resolve = false)
    {
        if (_typeCache.TryGetValue(typeName, out var typeInstance))
        {
            return typeInstance;
        }

        var resolveType = resolve ? _parentTypeResolver.ResolveType(typeName, resolve) : null;
        return resolveType;
    }
}
```

And then I added the MetadataReferences and AssemblyResolver to the container.

```
container.Register<AssemblyResolver>(ic => smartTypeResolver.ResolveAssembly, Lifespan.Singleton);
container.Register<MetadataReferenceProvider>(
            () => smartTypeResolver.MetadataReferences, Lifespan.Singleton);
```

This allows the test application (with a plugin) to resolve external types at compile time and runtime.