### PR TITLE
StandardReaderWriterLock needed Interlocked modification of _rLockCount.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,6 @@ jobs:
       - run: dotnet restore NEsperAll.sln
       - run: msbuild NEsper.proj
       - store_artifacts:
-          path: build/NEsper-8.5.7.zip
+          path: build/NEsper-8.5.8.zip
       - store_artifacts:
           path: build/packages

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<VersionPrefix Condition="'$(VersionPrefix)' == ''">8.5.7</VersionPrefix>
+		<VersionPrefix Condition="'$(VersionPrefix)' == ''">8.5.8</VersionPrefix>
 		<VersionSuffix Condition="'$(VersionSuffix)' == ''"></VersionSuffix>
 	</PropertyGroup>
 

--- a/NEsper.Documentation/NEsper.Documentation.shfbproj
+++ b/NEsper.Documentation/NEsper.Documentation.shfbproj
@@ -16,7 +16,7 @@
     <Name>NEsper.Documentation</Name>
     <!-- SHFB properties -->
     <FrameworkVersion>.NET Framework 4.6.2</FrameworkVersion>
-    <OutputPath>..\build\NEsper-8.5.7\docs\</OutputPath>
+    <OutputPath>..\build\NEsper-8.5.8\docs\</OutputPath>
     <HtmlHelpName>NEsper</HtmlHelpName>
     <Language>en-US</Language>
     <TransformComponentArguments>

--- a/NEsper.nuspec
+++ b/NEsper.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>NEsper</id>
-    <version>8.5.7</version>
+    <version>8.5.8</version>
     <authors>EsperTech</authors>
     <owners>EsperTech</owners>
     <language>en-us</language>
@@ -27,7 +27,7 @@
   </metadata>
 
   <files>
-    <file src="build\NEsper-8.5.7\lib\**" target="lib\{framework name}[{version}]" />
+    <file src="build\NEsper-8.5.8\lib\**" target="lib\{framework name}[{version}]" />
   </files>
 </package>
   

--- a/NEsper.proj
+++ b/NEsper.proj
@@ -8,7 +8,7 @@
     <SolutionDir>$(MSBuildProjectDirectory)</SolutionDir>
     <!-- Distribution version -->
     <Version Condition=" '$(CCNetLabel)' != '' ">$(CCNetLabel)</Version>
-    <Version Condition=" '$(Version)' == '' ">8.5.7</Version>
+    <Version Condition=" '$(Version)' == '' ">8.5.8</Version>
 
     <!-- Build Directories -->
     <BuildPath>$(MSBuildProjectDirectory)\build</BuildPath>

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ env:
   variables:
     MASTER_PROJECT: .\NEsper.proj
     PACKAGE_DIRECTORY: .\packages
-    VERSION: 8.5.7
+    VERSION: 8.5.8
 
 phases:
   build:

--- a/src/NEsper.Compat/compat/threading/locks/StandardReaderWriterLock.cs
+++ b/src/NEsper.Compat/compat/threading/locks/StandardReaderWriterLock.cs
@@ -9,211 +9,192 @@
 using System;
 using System.Threading;
 
-namespace com.espertech.esper.compat.threading.locks
-{
-    public sealed class StandardReaderWriterLock 
-        : IReaderWriterLock
-        , IReaderWriterLockCommon
-    {
+namespace com.espertech.esper.compat.threading.locks {
+    public sealed class StandardReaderWriterLock
+        : IReaderWriterLock, IReaderWriterLockCommon {
 #if (DEBUG && LOCK_TRACING) 
-        private readonly long _id = DebugId<StandardReaderWriterLock>.NewId();
+            private readonly long _id = DebugId<StandardReaderWriterLock>.NewId ();
 #endif
-        private readonly ReaderWriterLock _rwLock;
-        private int _rLockCount;
+            private readonly ReaderWriterLock _rwLock;
+            private int _rLockCount;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StandardReaderWriterLock"/> class.
-        /// </summary>
-        public StandardReaderWriterLock(int lockTimeout)
-        {
-            _rLockCount = 0;
-            _rwLock = new ReaderWriterLock();
-            ReadLock = new CommonReadLock(this, lockTimeout);
-            WriteLock = new CommonWriteLock(this, lockTimeout);
-        }
+            /// <summary>
+            /// Initializes a new instance of the <see cref="StandardReaderWriterLock"/> class.
+            /// </summary>
+            public StandardReaderWriterLock (int lockTimeout) {
+                _rLockCount = 0;
+                _rwLock = new ReaderWriterLock ();
+                ReadLock = new CommonReadLock (this, lockTimeout);
+                WriteLock = new CommonWriteLock (this, lockTimeout);
+            }
 
-        /// <summary>
-        /// Gets the read-side lockable
-        /// </summary>
-        /// <value></value>
-        public ILockable ReadLock { get ; }
+            /// <summary>
+            /// Gets the read-side lockable
+            /// </summary>
+            /// <value></value>
+            public ILockable ReadLock { get; }
 
-        /// <summary>
-        /// Gets the write-side lockable
-        /// </summary>
-        /// <value></value>
-        public ILockable WriteLock { get; }
+            /// <summary>
+            /// Gets the write-side lockable
+            /// </summary>
+            /// <value></value>
+            public ILockable WriteLock { get; }
 
-        public IDisposable AcquireReadLock()
-        {
-            return ReadLock.Acquire();
-        }
+            public IDisposable AcquireReadLock () {
+                return ReadLock.Acquire ();
+            }
 
-        public IDisposable AcquireWriteLock()
-        {
-            return WriteLock.Acquire();
-        }
+            public IDisposable AcquireWriteLock () {
+                return WriteLock.Acquire ();
+            }
 
-        public IDisposable AcquireWriteLock(TimeSpan lockWaitDuration)
-        {
-            return WriteLock.Acquire((long) lockWaitDuration.TotalMilliseconds);
-        }
+            public IDisposable AcquireWriteLock (TimeSpan lockWaitDuration) {
+                return WriteLock.Acquire ((long) lockWaitDuration.TotalMilliseconds);
+            }
 
-        public void ReleaseWriteLock()
-        {
-            ReleaseWriterLock();
-        }
+            public void ReleaseWriteLock () {
+                ReleaseWriterLock ();
+            }
 
 #if DEBUG
-        /// <summary>
-        /// Gets or sets a value indicating whether this <see cref="StandardReaderWriterLock"/> is TRACE.
-        /// </summary>
-        /// <value><c>true</c> if TRACE; otherwise, <c>false</c>.</value>
-        public bool Trace { get; set; }
+            /// <summary>
+            /// Gets or sets a value indicating whether this <see cref="StandardReaderWriterLock"/> is TRACE.
+            /// </summary>
+            /// <value><c>true</c> if TRACE; otherwise, <c>false</c>.</value>
+            public bool Trace { get; set; }
 #endif
 
-        public bool IsWriterLockHeld => _rwLock.IsWriterLockHeld;
+            public bool IsWriterLockHeld => _rwLock.IsWriterLockHeld;
 
-        /// <summary>
-        /// Acquires the reader lock.
-        /// </summary>
-        /// <param name="timeout">The timeout.</param>
-        public void AcquireReaderLock(long timeout)
-        {
-            try {
+            /// <summary>
+            /// Acquires the reader lock.
+            /// </summary>
+            /// <param name="timeout">The timeout.</param>
+            public void AcquireReaderLock (long timeout) {
+                try {
+#if (DEBUG && LOCK_TRACING) 
+                    if (true) {
+                        Console.WriteLine (
+                            "{0}: AcquireReaderLock: {1} - Start ({2})",
+                            Thread.CurrentThread.ManagedThreadId,
+                            _id,
+                            _rLockCount);
+                    }
+#endif
+                    if (_rwLock.IsReaderLockHeld) {
+                        Interlocked.Increment (ref _rLockCount);
+                    } else if (_rwLock.IsWriterLockHeld) {
+                        Interlocked.Increment (ref _rLockCount);
+                    } else {
+                        _rwLock.AcquireReaderLock ((int) timeout);
+                        Interlocked.Increment (ref _rLockCount);
+                    }
+#if (DEBUG && LOCK_TRACING) 
+                    if (true) {
+                        Console.WriteLine (
+                            "{0}: AcquireReaderLock: {1} - Acquired ({2})\n",
+                            Thread.CurrentThread.ManagedThreadId,
+                            _id,
+                            _rLockCount);
+                    }
+#endif
+                } catch (ApplicationException) {
+                    throw new TimeoutException ("ReaderWriterLock timeout expired");
+                }
+            }
+
+            /// <summary>
+            /// Acquires the writer lock.
+            /// </summary>
+            /// <param name="timeout">The timeout.</param>
+            public void AcquireWriterLock (long timeout) {
+                try {
+#if (DEBUG && LOCK_TRACING) 
+                    if (true) {
+                        Console.WriteLine (
+                            "{0}: AcquireWriterLock: {1} - Start",
+                            Thread.CurrentThread.ManagedThreadId,
+                            _id);
+                    }
+#endif
+                    _rwLock.AcquireWriterLock ((int) timeout);
+#if (DEBUG && LOCK_TRACING) 
+                    if (true) {
+                        Console.WriteLine (
+                            "{0}: AcquireWriterLock: {1} - Acquired",
+                            Thread.CurrentThread.ManagedThreadId,
+                            _id);
+                    }
+#endif
+                } catch (ApplicationException) {
+                    throw new TimeoutException ("ReaderWriterLock timeout expired");
+                }
+            }
+
+            /// <summary>
+            /// Releases the reader lock.
+            /// </summary>
+            public void ReleaseReaderLock () {
 #if (DEBUG && LOCK_TRACING) 
                 if (true) {
-                    Console.WriteLine(
-                        "{0}: AcquireReaderLock: {1} - Start ({2})",
+                    Console.WriteLine (
+                        "{0}: ReleaseReaderLock: {1} - Start ({2})",
                         Thread.CurrentThread.ManagedThreadId,
                         _id,
                         _rLockCount);
                 }
 #endif
-                if (_rwLock.IsReaderLockHeld) {
-                    _rLockCount++;
-                } else if (_rwLock.IsWriterLockHeld) {
-                    _rLockCount++;
-                }
-                else {
-                    _rwLock.AcquireReaderLock((int)timeout);
-                    _rLockCount = 1;
+                if (_rwLock.IsWriterLockHeld) {
+                    // if the writer lock is held, then it means we acquired the reader lock under the
+                    // exclusion of the writer lock.  But if the rLockCount is zero, then it means we
+                    // are doing something wrong
+                    if (_rLockCount == 0) {
+                        throw new LockException ("cannot release writer lock through reader mechanism");
+                    }
+
+                    // Decrease the rLockCount.  There is no need to check the rLockCount because it
+                    // should never go below zero.  We might want to check the rLockCount on writer
+                    // lock release.
+                    Interlocked.Decrement (ref _rLockCount);
+                } else if (_rwLock.IsReaderLockHeld) {
+                    if (Interlocked.Decrement (ref _rLockCount) == 0) {
+                        _rwLock.ReleaseReaderLock ();
+                    }
+                } else {
+                    throw new LockException ("Attempt to release a lock that is not owned by the calling thread");
                 }
 #if (DEBUG && LOCK_TRACING) 
                 if (true) {
-                    Console.WriteLine(
-                        "{0}: AcquireReaderLock: {1} - Acquired ({2})\n",
+                    Console.WriteLine (
+                        "{0}: ReleaseReaderLock: {1} - Released ({2})",
                         Thread.CurrentThread.ManagedThreadId,
                         _id,
                         _rLockCount);
                 }
 #endif
             }
-            catch (ApplicationException)
-            {
-                throw new TimeoutException("ReaderWriterLock timeout expired");
-            }
-        }
 
-        /// <summary>
-        /// Acquires the writer lock.
-        /// </summary>
-        /// <param name="timeout">The timeout.</param>
-        public void AcquireWriterLock(long timeout)
-        {
-            try
-            {
+            /// <summary>
+            /// Releases the writer lock.
+            /// </summary>
+            public void ReleaseWriterLock () {
 #if (DEBUG && LOCK_TRACING) 
                 if (true) {
-                    Console.WriteLine(
-                        "{0}: AcquireWriterLock: {1} - Start",
+                    Console.WriteLine (
+                        "{0}: ReleaseWriterLock: {1} - Start",
                         Thread.CurrentThread.ManagedThreadId,
                         _id);
                 }
 #endif
-                _rwLock.AcquireWriterLock((int)timeout);
+                _rwLock.ReleaseWriterLock ();
 #if (DEBUG && LOCK_TRACING) 
                 if (true) {
-                    Console.WriteLine(
-                        "{0}: AcquireWriterLock: {1} - Acquired",
+                    Console.WriteLine (
+                        "{0}: ReleaseWriterLock: {1} - Released",
                         Thread.CurrentThread.ManagedThreadId,
                         _id);
                 }
 #endif
             }
-            catch (ApplicationException)
-            {
-                throw new TimeoutException("ReaderWriterLock timeout expired");
-            }
         }
-
-        /// <summary>
-        /// Releases the reader lock.
-        /// </summary>
-        public void ReleaseReaderLock()
-        {
-#if (DEBUG && LOCK_TRACING) 
-            if (true) {
-                Console.WriteLine(
-                    "{0}: ReleaseReaderLock: {1} - Start ({2})",
-                    Thread.CurrentThread.ManagedThreadId,
-                    _id,
-                    _rLockCount);
-            }
-#endif
-            if (_rwLock.IsWriterLockHeld) {
-                // if the writer lock is held, then it means we acquired the reader lock under the
-                // exclusion of the writer lock.  But if the rLockCount is zero, then it means we
-                // are doing something wrong
-                if (_rLockCount == 0) {
-                    throw new LockException("cannot release writer lock through reader mechanism");
-                }
-
-                // Decrease the rLockCount.  There is no need to check the rLockCount because it
-                // should never go below zero.  We might want to check the rLockCount on writer
-                // lock release.
-                _rLockCount--;
-            } else if (_rwLock.IsReaderLockHeld) {
-                if (--_rLockCount == 0) {
-                    _rwLock.ReleaseReaderLock();
-                }
-            }
-            else {
-                throw new LockException("Attempt to release a lock that is not owned by the calling thread");
-            }
-#if (DEBUG && LOCK_TRACING) 
-            if (true) {
-                Console.WriteLine(
-                    "{0}: ReleaseReaderLock: {1} - Released ({2})",
-                    Thread.CurrentThread.ManagedThreadId,
-                    _id,
-                    _rLockCount);
-            }
-#endif
-        }
-
-        /// <summary>
-        /// Releases the writer lock.
-        /// </summary>
-        public void ReleaseWriterLock()
-        {
-#if (DEBUG && LOCK_TRACING) 
-            if (true) {
-                Console.WriteLine(
-                    "{0}: ReleaseWriterLock: {1} - Start",
-                    Thread.CurrentThread.ManagedThreadId,
-                    _id);
-            }
-#endif
-            _rwLock.ReleaseWriterLock();
-#if (DEBUG && LOCK_TRACING) 
-            if (true) {
-                Console.WriteLine(
-                    "{0}: ReleaseWriterLock: {1} - Released",
-                    Thread.CurrentThread.ManagedThreadId,
-                    _id);
-            }
-#endif
-        }
-    }
 }

--- a/src/NEsper.Compiler/internal/util/CompilerVersion.cs
+++ b/src/NEsper.Compiler/internal/util/CompilerVersion.cs
@@ -10,6 +10,6 @@ namespace com.espertech.esper.compiler.@internal.util
 {
     public class CompilerVersion
     {
-        public const string COMPILER_VERSION = "8.5.7";
+        public const string COMPILER_VERSION = "8.5.8";
     }
 } // end of namespace

--- a/src/NEsper.Compiler/internal/util/Version.cs
+++ b/src/NEsper.Compiler/internal/util/Version.cs
@@ -11,7 +11,7 @@ namespace com.espertech.esper.compiler.@internal.util
     public class Version
     {
         public static string COMPILER_VERSION {
-            get => "8.5.7";
+            get => "8.5.8";
         }
     }
 } // end of namespace

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarBaseListener.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarBaseListener.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.7\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.8\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarBaseVisitor.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarBaseVisitor.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.7\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.8\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarLexer.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarLexer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.7\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.8\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarListener.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarListener.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.7\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.8\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarParser.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarParser.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.7\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.8\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarVisitor.cs
+++ b/src/NEsper.Grammar/internal/generated/EsperEPL2GrammarVisitor.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generated from C:\Src\Espertech\NEsper-8.5.7\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
+// Generated from C:\Src\Espertech\NEsper-8.5.8\NEsper\grammar\EsperEPL2Grammar.g4 by ANTLR 4.7.1
 
 // Unreachable code detected
 #pragma warning disable 0162

--- a/src/NEsper.Runtime/client/util/RuntimeVersion.cs
+++ b/src/NEsper.Runtime/client/util/RuntimeVersion.cs
@@ -19,7 +19,7 @@ namespace com.espertech.esper.runtime.client.util
         /// <summary>
         ///     Current runtime version.
         /// </summary>
-        public const string RUNTIME_VERSION = "8.5.7";
+        public const string RUNTIME_VERSION = "8.5.8";
 
         /// <summary>
         ///     Current runtime major version.

--- a/tst/NEsper.Regression/suite/client/deploy/ClientDeployVersion.cs
+++ b/tst/NEsper.Regression/suite/client/deploy/ClientDeployVersion.cs
@@ -37,7 +37,7 @@ namespace com.espertech.esper.regressionlib.suite.client.deploy
 				EPCompiled compiled = EPCompiledIOUtil.Read(new File(file));
 
 				var versionMismatchMsg =
-					"Major or minor version of compiler and runtime mismatch; The runtime version is 8.5.7 and the compiler version of the compiled unit is 8.0.0";
+					"Major or minor version of compiler and runtime mismatch; The runtime version is 8.5.8 and the compiler version of the compiled unit is 8.0.0";
 				AssertMessage(
 					Assert.Throws<EPDeployDeploymentVersionException>(
 						() => env.Runtime.DeploymentService.Deploy(compiled)),
@@ -51,7 +51,7 @@ namespace com.espertech.esper.regressionlib.suite.client.deploy
 				AssertMessage(
 					Assert.Throws<EPException>(
 						() => env.Runtime.FireAndForgetService.ExecuteQuery(compiled)),
-					"Major or minor version of compiler and runtime mismatch; The runtime version is 8.5.7 and the compiler version of the compiled unit is 8.0.0");
+					"Major or minor version of compiler and runtime mismatch; The runtime version is 8.5.8 and the compiler version of the compiled unit is 8.0.0");
 #endif
 			}
 		}


### PR DESCRIPTION
The lock counters needed to be modified with System.Threading.Interlocked because two reader threads can modify them concurrently.